### PR TITLE
Explicita mensagem de erro no log

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -265,8 +265,8 @@ export function activate(context: vscode.ExtensionContext) {
         const diskVersions = findAvailableDiskVersions(rootPrefix);
 
         if (!diskVersions) {
-            vscode.window.showErrorMessage(`Não há sequer uma versão da documentação instalada`);
-            outLog.appendLine(`Não há sequer uma versão da documentação instalada`);
+            vscode.window.showErrorMessage(`Não há sequer uma versão da documentação instalada na pasta: ${path.resolve(rootPrefix)}`);
+            outLog.appendLine(`Não há sequer uma versão da documentação instalada na pasta: ${path.resolve(rootPrefix)}`);
             return;
         }
         const bestDiskVersion = findBestVersion(diskVersions,preferredVersion);


### PR DESCRIPTION
Indica no log a pasta que não foi encontrada.
Algumas vezes a documentação não é instalada para determinado simulador em determinada versão.